### PR TITLE
Add a launcher for jstat

### DIFF
--- a/closed/make/closed_make/launcher/Launcher-jdk.jcmd.gmk
+++ b/closed/make/closed_make/launcher/Launcher-jdk.jcmd.gmk
@@ -46,3 +46,9 @@ $(eval $(call SetupBuildLauncher, jstack, \
     MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jstack, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))
+
+$(eval $(call SetupBuildLauncher, jstat, \
+	    MAIN_MODULE := jdk.jcmd, \
+	    MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jstat, \
+	    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+	))


### PR DESCRIPTION
**Add a launcher for jstat**

Added a launcher for `jstat`.

depends: https://github.com/eclipse/openj9/pull/7240

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>